### PR TITLE
utils: introduce heap_heap library

### DIFF
--- a/utils/heap_help/README.md
+++ b/utils/heap_help/README.md
@@ -1,0 +1,19 @@
+The utility helps to detect incorrect heap usage like memory leaks. It works via
+redefinition of the standard functions which are expected to allocate something
+on the heap.
+
+To use it you need to build it as a part of your application. Just compile the
+`.c` file along with your other files. Or build it as a shared library (.so in
+Linux, .dylib in Mac and then build your code with the resulting lib file.
+
+Then in the code you need to call `heaph_init()` first line in your `main()`
+function.
+
+After that in any moment you can track how many not freed allocations you have
+via `heaph_get_alloc_count()`. Ideally before your `main()` function returns
+this number should be zero.
+
+Shared library build command for Mac:
+```
+clang -shared -undefined dynamic_lookup -o libheap.dylib heap_help.c
+```

--- a/utils/heap_help/heap_help.c
+++ b/utils/heap_help/heap_help.c
@@ -1,0 +1,92 @@
+#define _GNU_SOURCE
+#include "heap_help.h"
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void *(*default_malloc)(size_t) = NULL;
+void (*default_free)() = NULL;
+void *(*default_calloc)(size_t, size_t) = NULL;
+void *(*default_realloc)(void *, size_t) = NULL;
+char *(*default_strdup)(const char *) = NULL;
+ssize_t (*default_getline)(char **, size_t *, FILE *) = NULL;
+
+static uint64_t alloc_count = 0;
+
+ssize_t
+getline(char **linep, size_t *linecapp, FILE *stream)
+{
+	char *line_old = *linep;
+	ssize_t res = default_getline(linep, linecapp, stream);
+	if (line_old == NULL && *linep != NULL)
+		++alloc_count;
+	return res;
+}
+
+char *
+strdup(const char *ptr)
+{
+	char *res = default_strdup(ptr);
+	if (res != NULL)
+		++alloc_count;
+	return res;
+}
+
+void *
+malloc(size_t size)
+{
+	void *res = default_malloc(size);
+	if (res != NULL)
+		++alloc_count;
+	return res;
+}
+
+void *
+calloc(size_t num, size_t size)
+{
+	void *res = default_calloc(num, size);
+	if (res != NULL)
+		++alloc_count;
+	return res;
+}
+
+void *
+realloc(void *ptr, size_t size)
+{
+	void *res = default_realloc(ptr, size);
+	if (ptr == NULL && res != NULL)
+		++alloc_count;
+	return res;
+}
+
+void
+free(void *ptr)
+{
+	if (ptr == NULL)
+		return;
+	default_free(ptr);
+	if (alloc_count == 0) {
+		printf("Double-free\n");
+		exit(1);
+	}
+	--alloc_count;
+}
+
+void
+heaph_init(void)
+{
+	default_getline = dlsym(RTLD_NEXT, "getline");
+	default_strdup = dlsym(RTLD_NEXT, "strdup");
+	default_malloc = dlsym(RTLD_NEXT, "malloc");
+	default_calloc = dlsym(RTLD_NEXT, "calloc");
+	default_realloc = dlsym(RTLD_NEXT, "realloc");
+	default_free = dlsym(RTLD_NEXT, "free");
+}
+
+uint64_t
+heaph_get_alloc_count(void)
+{
+	return alloc_count;
+}

--- a/utils/heap_help/heap_help.h
+++ b/utils/heap_help/heap_help.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <stdint.h>
+
+void
+heaph_init(void);
+
+uint64_t
+heaph_get_alloc_count(void);


### PR DESCRIPTION
It tracks number of allocations and can help with detecting memory leaks.

On Mac it was tested, on Linux was not, but most likely will work the same.

The idea is that libc heap-related functions are expected to be weak symbols. Meaning they can be redefined. The library simply redefines the functions which students are expected to use and tracks how many allocations remain unfreed.